### PR TITLE
Add MultiWorld to `softdepend` to prevent plugin not detect external worlds

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -9,3 +9,4 @@ softdepend:
   - PlaceholderAPI
   - Multiverse-Core
   - Worlds
+  - MultiWorld


### PR DESCRIPTION
Plugin: https://github.com/Dev7ex/MultiWorld


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin compatibility configuration to support additional integrations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->